### PR TITLE
 Better and more secure way to create new ProjectDataItem instances

### DIFF
--- a/Commands/CmdLines.h
+++ b/Commands/CmdLines.h
@@ -40,7 +40,7 @@ public:
         // copy directions
         QList<LineDirection *> directionCopies;
         for(int i = 0; i < oldL.directionCount(); i++)
-            directionCopies << new LineDirection(*oldL.directionAt(i));
+            directionCopies << line->newDirection(*oldL.directionAt(i));
         oldL.setDirections(directionCopies);
     }
 

--- a/Dialogs/DlgLineeditor.cpp
+++ b/Dialogs/DlgLineeditor.cpp
@@ -70,7 +70,8 @@ void DlgLineEditor::actionNewDirection() {
     if(!ok || newName.isEmpty())
         return;
 
-    LineDirection *ld = new LineDirection(nullptr, global::getNewID(), newName);
+    LineDirection *ld = new LineDirection(nullptr, global::getNewID());
+    ld->setDescription(newName);
     _line.addDirection(ld);
     ui->lwDirections->addItem(newName);
 }

--- a/Dialogs/DlgLineeditor.h
+++ b/Dialogs/DlgLineeditor.h
@@ -16,7 +16,7 @@ class DlgLineEditor : public QDialog
     Q_OBJECT
 
 public:
-    explicit DlgLineEditor(QWidget *parent = nullptr, Line l = Line(nullptr, global::getNewID(), ""));
+    explicit DlgLineEditor(QWidget *parent = nullptr, Line l = Line(nullptr, ProjectDataItem::getNewID()));
     ~DlgLineEditor();
 
     Line line();

--- a/Dialogs/DlgProjectsettings.cpp
+++ b/Dialogs/DlgProjectsettings.cpp
@@ -141,7 +141,7 @@ void DlgProjectSettings::on_pbDayNew_clicked() {
     if(!ok)
         return;
 
-    DayType *d = new DayType(nullptr, global::getNewID(), name, 0);
+    DayType *d = new DayType(nullptr, ProjectDataItem::getNewID(), name, 0);
     tableReference << d;
     _currentDayType = d;
     refreshDayTypesTable();

--- a/Dialogs/DlgRouteeditor.cpp
+++ b/Dialogs/DlgRouteeditor.cpp
@@ -243,7 +243,8 @@ void routeEditor::on_pbProfileNew_clicked()
     float duration = dlg.getDuration();
     QList<TimeProfileItem *> itemList = dlg.getTimeProfileItemList();
 
-    TimeProfile *t = new TimeProfile(nullptr, global::getNewID(), name);
+    TimeProfile *t = routeData->newTimeProfile();
+    t->setName(name);
     t->setDuration(duration);
     t->addBusstops(itemList);
 

--- a/Plugins/PlgOmsiImport.cpp
+++ b/Plugins/PlgOmsiImport.cpp
@@ -97,7 +97,8 @@ void PlgOmsiImport::run() {
                 QString name = s.readLine();
                 Busstop *b = projectData->busstopWithName(name);
                 if(!b) {
-                    b = new Busstop(projectData, global::getNewID(), name);
+                    b = projectData->newBusstop();
+                    b->setName(name);
                     projectData->addBusstop(b);
                     qInfo() << "new busstop created:" << name;
                 }
@@ -113,7 +114,8 @@ void PlgOmsiImport::run() {
                 QString name = busstopsFromCfg[id];
                 Busstop *b = projectData->busstopWithName(name);
                 if(!b) {
-                    b = new Busstop(projectData, global::getNewID(), name);
+                    b = projectData->newBusstop();
+                    b->setName(name);
                     projectData->addBusstop(b);
                     qInfo() << "new busstop created:" << name;
                 }

--- a/Plugins/PlgOmsiImport.cpp
+++ b/Plugins/PlgOmsiImport.cpp
@@ -359,9 +359,22 @@ void PlgOmsiImport::run() {
     }
 
     qInfo() << "generating day types";
-    projectData->projectSettings()->addDayType(new DayType(projectData, global::getNewID(), tr("Monday - Friday"), 995));
-    projectData->projectSettings()->addDayType(new DayType(projectData, global::getNewID(), tr("Saturday"), 19));
-    projectData->projectSettings()->addDayType(new DayType(projectData, global::getNewID(), tr("Sunday & Holiday"), 15));
+    DayType *d1 = projectData->projectSettings()->newDayType();
+    DayType *d2 = projectData->projectSettings()->newDayType();
+    DayType *d3 = projectData->projectSettings()->newDayType();
+
+    d1->setName(tr("Monday - Friday"));
+    d1->setCode(995);
+
+    d2->setName(tr("Saturday"));
+    d2->setCode(19);
+
+    d3->setName(tr("Sunday & Holiday"));
+    d3->setCode(15);
+
+    projectData->projectSettings()->addDayType(d1);
+    projectData->projectSettings()->addDayType(d2);
+    projectData->projectSettings()->addDayType(d3);
 }
 
 void PlgOmsiImport::setMapDirectory(const QString &path) {

--- a/Plugins/PlgOmsiImport.cpp
+++ b/Plugins/PlgOmsiImport.cpp
@@ -70,7 +70,9 @@ void PlgOmsiImport::run() {
                          QRandomGenerator::global()->bounded(256),
                          QRandomGenerator::global()->bounded(256));
 
-            l = new Line(projectData, global::getNewID(), lineName, "", color);
+            l = projectData->newLine();
+            l->setName(lineName);
+            l->setColor(color);
             qInfo() << "new line created:" << lineName;
             projectData->addLine(l);
             ld1 = new LineDirection(l, global::getNewID(), "Direction 1");

--- a/Plugins/PlgOmsiImport.cpp
+++ b/Plugins/PlgOmsiImport.cpp
@@ -133,7 +133,8 @@ void PlgOmsiImport::run() {
                 bool ok;
                 duration = durationStr.toFloat(&ok);
 
-                TimeProfile *p = new TimeProfile(r, global::getNewID(), name);
+                TimeProfile *p = r->newTimeProfile();
+                p->setName(name);
                 p->setDuration(duration);
                 r->addTimeProfile(p);
 

--- a/Plugins/PlgOmsiImport.cpp
+++ b/Plugins/PlgOmsiImport.cpp
@@ -236,7 +236,9 @@ void PlgOmsiImport::run() {
                 s.readLine();
                 QString dayStr = s.readLine();
                 WeekDays w = importWeekDays(dayStr);
-                Tour *o = new Tour(projectData, global::getNewID(), name, w);
+                Tour *o = projectData->newTour();
+                o->setName(name);
+                o->setWeekDays(w);
                 projectData->addTour(o);
 
                 while(!s.atEnd()) {

--- a/Plugins/PlgOmsiImport.cpp
+++ b/Plugins/PlgOmsiImport.cpp
@@ -82,7 +82,9 @@ void PlgOmsiImport::run() {
         }
         ld1 = l->directionAt(0);
 
-        Route *r = new Route(l, global::getNewID(), 1, currentTrip, ld1);
+        Route *r = l->newRoute();
+        r->setName(currentTrip);
+        r->setDirection(ld1);
         l->addRoute(r);
 
         QTextStream s(&f);

--- a/Plugins/PlgOmsiImport.cpp
+++ b/Plugins/PlgOmsiImport.cpp
@@ -294,7 +294,11 @@ void PlgOmsiImport::run() {
                             }
                         }
 
-                        Trip *t = new Trip(l, global::getNewID(), r, time, p, w);
+                        Trip *t = l->newTrip();
+                        t->setRoute(r);
+                        t->setStartTime(time);
+                        t->setTimeProfile(p);
+                        t->setWeekDays(w);
                         l->addTrip(t);
                         o->addTrip(t);
                     }

--- a/Plugins/PlgOmsiImport.cpp
+++ b/Plugins/PlgOmsiImport.cpp
@@ -75,8 +75,10 @@ void PlgOmsiImport::run() {
             l->setColor(color);
             qInfo() << "new line created:" << lineName;
             projectData->addLine(l);
-            ld1 = new LineDirection(l, global::getNewID(), "Direction 1");
-            ld2 = new LineDirection(l, global::getNewID(), "Direction 2");
+            ld1 = l->newDirection();
+            ld2 = l->newDirection();
+            ld1->setDescription("Direction 1");
+            ld2->setDescription("Direction 2");
             l->addDirection(ld1);
             l->addDirection(ld2);
         }

--- a/ProjectData/ProjectDataItem.cpp
+++ b/ProjectData/ProjectDataItem.cpp
@@ -5,8 +5,8 @@
 ProjectDataItem::ProjectDataItem(QObject *parent, const QString &id) :
     QObject(parent),
     _id(id) {
-    if(this->id() == "")
-        _id = global::getNewID();
+    if(this->id().isEmpty())
+        _id = getNewID();
 }
 
 ProjectDataItem::ProjectDataItem(QObject *parent, const QJsonObject &jsonObject) :
@@ -46,4 +46,8 @@ QJsonObject ProjectDataItem::toJson() const {
 
 void ProjectDataItem::refreshChilds() {
     //
+}
+
+QString ProjectDataItem::getNewID() {
+    return QUuid::createUuid().toString(QUuid::WithoutBraces);
 }

--- a/ProjectData/ProjectDataItem.h
+++ b/ProjectData/ProjectDataItem.h
@@ -16,6 +16,8 @@ public:
 
     void refreshChilds();
 
+    static QString getNewID();
+
 protected:
     void copy(const ProjectDataItem &);
     void fromJson(const QJsonObject &);

--- a/ProjectData/busstop.cpp
+++ b/ProjectData/busstop.cpp
@@ -1,7 +1,7 @@
 #include "ProjectData/busstop.h"
 
-Busstop::Busstop(QObject *parent, const QString &id, const QString &name, const bool &important) :
-    ProjectDataItem(parent, id), _name(name), _important(important) {}
+Busstop::Busstop(QObject *parent, const QString &id) :
+    ProjectDataItem(parent, id) {}
 
 Busstop::Busstop(QObject *parent, const QJsonObject &jsonObject) :
     ProjectDataItem(parent) {

--- a/ProjectData/busstop.cpp
+++ b/ProjectData/busstop.cpp
@@ -1,10 +1,10 @@
 #include "ProjectData/busstop.h"
 
 Busstop::Busstop(QObject *parent, const QString &id) :
-    ProjectDataItem(parent, id) {}
+    ProjectDataItem(parent, id), _important(false) {}
 
 Busstop::Busstop(QObject *parent, const QJsonObject &jsonObject) :
-    ProjectDataItem(parent) {
+    ProjectDataItem(parent), _important(false) {
     fromJson(jsonObject);
 }
 

--- a/ProjectData/busstop.h
+++ b/ProjectData/busstop.h
@@ -8,7 +8,7 @@
 class Busstop : public virtual ProjectDataItem {
     Q_OBJECT
 public:
-    Busstop(QObject *parent, const QString &id, const QString &name, const bool &important = false);
+    Busstop(QObject *parent, const QString &id);
     Busstop(QObject *parent, const QJsonObject &);
     Busstop(const Busstop &);
     Busstop operator=(const Busstop &other);

--- a/ProjectData/footnote.cpp
+++ b/ProjectData/footnote.cpp
@@ -1,12 +1,7 @@
 #include "footnote.h"
 
-Footnote::Footnote(QObject *parent,
-                   const QString &id,
-                   const QString &identifier,
-                   const QString &name,
-                   const QString &description) :
+Footnote::Footnote(QObject *parent, const QString &id) :
     ProjectDataItem(parent, id),
-    _identifier(identifier), _name(name), _description(description),
     _autoAssignWeekDaysEnabled(false) {}
 
 Footnote::Footnote(QObject *parent, const QJsonObject &jsonObject) : ProjectDataItem(parent) {

--- a/ProjectData/footnote.h
+++ b/ProjectData/footnote.h
@@ -10,7 +10,7 @@
 class Footnote : public virtual ProjectDataItem {
     Q_OBJECT
 public:
-    Footnote(QObject *parent, const QString &id, const QString &identifier, const QString &name, const QString &description = "");
+    Footnote(QObject *parent, const QString &id);
     Footnote(QObject *parent, const QJsonObject &);
     Footnote(const Footnote &);
     Footnote operator=(const Footnote &);

--- a/ProjectData/line.cpp
+++ b/ProjectData/line.cpp
@@ -99,7 +99,7 @@ void Line::fromJson(const QJsonObject &jsonObject) {
 
     for(int i = 0; i < jTrips.count(); ++i)
         if(jTrips[i].isObject())
-            addTrip(new Trip(this, jTrips[i].toObject()));
+            addTrip(newTrip(jTrips[i].toObject()));
 }
 
 
@@ -421,4 +421,20 @@ Route *Line::newRoute(const Route &newRoute) {
     Route *r = new Route(newRoute);
     r->setParent(this);
     return r;
+}
+
+Trip *Line::newTrip(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new Trip(this, id);
+}
+
+Trip *Line::newTrip(const QJsonObject &obj) {
+    return new Trip(this, obj);
+}
+
+Trip *Line::newTrip(const Trip &newTrip) {
+    Trip *t = new Trip(newTrip);
+    t->setParent(this);
+    return t;
 }

--- a/ProjectData/line.cpp
+++ b/ProjectData/line.cpp
@@ -95,7 +95,7 @@ void Line::fromJson(const QJsonObject &jsonObject) {
 
     for(int i = 0; i < jRoutes.count(); ++i)
         if(jRoutes[i].isObject())
-            addRoute(new Route(this, jRoutes[i].toObject()));
+            addRoute(newRoute(jRoutes[i].toObject()));
 
     for(int i = 0; i < jTrips.count(); ++i)
         if(jTrips[i].isObject())
@@ -403,4 +403,22 @@ LineDirection *Line::directionOfTrip(Trip *t) const {
         return nullptr;
 
     return t->route()->direction();
+}
+
+
+
+Route *Line::newRoute(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new Route(this, id);
+}
+
+Route *Line::newRoute(const QJsonObject &obj) {
+    return new Route(this, obj);
+}
+
+Route *Line::newRoute(const Route &newRoute) {
+    Route *r = new Route(newRoute);
+    r->setParent(this);
+    return r;
 }

--- a/ProjectData/line.cpp
+++ b/ProjectData/line.cpp
@@ -1,7 +1,7 @@
 #include "ProjectData\line.h"
 
-Line::Line(QObject *parent, const QString &id, const QString &name, const QString &description, const QColor &color) :
-    ProjectDataItem(parent, id), _name(name), _description(description), _color(color) {}
+Line::Line(QObject *parent, const QString &id) :
+    ProjectDataItem(parent, id) {}
 
 Line::Line(QObject *parent, const QJsonObject &jsonObject) :
     ProjectDataItem(parent) {

--- a/ProjectData/line.cpp
+++ b/ProjectData/line.cpp
@@ -91,7 +91,7 @@ void Line::fromJson(const QJsonObject &jsonObject) {
 
     for(int i = 0; i < jDirections.count(); ++i)
         if(jDirections[i].isObject())
-            addDirection(new LineDirection(this, jDirections[i].toObject()));
+            addDirection(newDirection(jDirections[i].toObject()));
 
     for(int i = 0; i < jRoutes.count(); ++i)
         if(jRoutes[i].isObject())
@@ -406,6 +406,21 @@ LineDirection *Line::directionOfTrip(Trip *t) const {
 }
 
 
+LineDirection *Line::newDirection(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new LineDirection(this, id);
+}
+
+LineDirection *Line::newDirection(const QJsonObject &obj) {
+    return new LineDirection(this, obj);
+}
+
+LineDirection *Line::newDirection(const LineDirection &newDirection) {
+    LineDirection *ld = new LineDirection(newDirection);
+    ld->setParent(this);
+    return ld;
+}
 
 Route *Line::newRoute(QString id) {
     if(id.isEmpty())

--- a/ProjectData/line.h
+++ b/ProjectData/line.h
@@ -72,6 +72,10 @@ public:
 
     void refreshChilds();
 
+    Route *newRoute(QString id = "");
+    Route *newRoute(const QJsonObject &obj);
+    Route *newRoute(const Route &newRoute);
+
 protected:
     void copy(const Line &);
     void fromJson(const QJsonObject &);

--- a/ProjectData/line.h
+++ b/ProjectData/line.h
@@ -72,6 +72,10 @@ public:
 
     void refreshChilds();
 
+    LineDirection *newDirection(QString id = "");
+    LineDirection *newDirection(const QJsonObject &obj);
+    LineDirection *newDirection(const LineDirection &newDirection);
+
     Route *newRoute(QString id = "");
     Route *newRoute(const QJsonObject &obj);
     Route *newRoute(const Route &newRoute);

--- a/ProjectData/line.h
+++ b/ProjectData/line.h
@@ -14,7 +14,7 @@
 class Line : public virtual ProjectDataItem {
     Q_OBJECT
 public:
-    Line(QObject *parent, const QString &id, const QString &name, const QString &description = "", const QColor &color = QColor(0, 0, 0));
+    Line(QObject *parent, const QString &id);
     Line(QObject *parent, const QJsonObject &);
     Line(const Line &);
 

--- a/ProjectData/line.h
+++ b/ProjectData/line.h
@@ -76,6 +76,10 @@ public:
     Route *newRoute(const QJsonObject &obj);
     Route *newRoute(const Route &newRoute);
 
+    Trip *newTrip(QString id = "");
+    Trip *newTrip(const QJsonObject &obj);
+    Trip *newTrip(const Trip &newTrip);
+
 protected:
     void copy(const Line &);
     void fromJson(const QJsonObject &);

--- a/ProjectData/linedirection.cpp
+++ b/ProjectData/linedirection.cpp
@@ -1,7 +1,7 @@
 #include "linedirection.h"
 
-LineDirection::LineDirection(QObject *parent, const QString &id, const QString &description) :
-    ProjectDataItem(parent, id), _description(description) {}
+LineDirection::LineDirection(QObject *parent, const QString &id) :
+    ProjectDataItem(parent, id) {}
 
 LineDirection::LineDirection(QObject *parent, const QJsonObject &jsonObject) :
     ProjectDataItem(parent) {

--- a/ProjectData/linedirection.h
+++ b/ProjectData/linedirection.h
@@ -6,7 +6,7 @@
 class LineDirection : public virtual ProjectDataItem {
     Q_OBJECT
 public:
-    LineDirection(QObject *parent, const QString &id, const QString &description);
+    LineDirection(QObject *parent, const QString &id);
     LineDirection(QObject *parent, const QJsonObject &);
     LineDirection(const LineDirection &);
     LineDirection operator=(const LineDirection &);

--- a/ProjectData/projectdata.cpp
+++ b/ProjectData/projectdata.cpp
@@ -618,7 +618,7 @@ void ProjectData::setJson(const QJsonObject &jsonObject) {
     for(int i = 0; i < jLines.count(); ++i)
         if(jLines[i].isObject()) {
             counter++;
-            addLine(new Line(this, jLines[i].toObject()));
+            addLine(newLine(jLines[i].toObject()));
         } else invalidCounter++;
 
     qInfo().noquote() << counter << "valid lines found (" + QString::number(invalidCounter) + " invalid)";
@@ -659,4 +659,20 @@ Busstop *ProjectData::newBusstop(const Busstop &newBusstop) {
     Busstop *b = new Busstop(newBusstop);
     b->setParent(this);
     return b;
+}
+
+Line *ProjectData::newLine(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new Line(this, id);
+}
+
+Line *ProjectData::newLine(const QJsonObject &obj) {
+    return new Line(this, obj);
+}
+
+Line *ProjectData::newLine(const Line &newLine) {
+    Line *l = new Line(newLine);
+    l->setParent(this);
+    return l;
 }

--- a/ProjectData/projectdata.cpp
+++ b/ProjectData/projectdata.cpp
@@ -627,7 +627,7 @@ void ProjectData::setJson(const QJsonObject &jsonObject) {
     for(int i = 0; i < jTours.count(); ++i)
         if(jTours[i].isObject()) {
             counter++;
-            addTour(new Tour(this, jTours[i].toObject()));
+            addTour(newTour(jTours[i].toObject()));
         } else invalidCounter++;
 
     qInfo().noquote() << counter << "valid tours found (" + QString::number(invalidCounter) + " invalid)";
@@ -675,4 +675,20 @@ Line *ProjectData::newLine(const Line &newLine) {
     Line *l = new Line(newLine);
     l->setParent(this);
     return l;
+}
+
+Tour *ProjectData::newTour(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new Tour(this, id);
+}
+
+Tour *ProjectData::newTour(const QJsonObject &obj) {
+    return new Tour(this, obj);
+}
+
+Tour *ProjectData::newTour(const Tour &newTour) {
+    Tour *o = new Tour(newTour);
+    o->setParent(this);
+    return o;
 }

--- a/ProjectData/projectdata.cpp
+++ b/ProjectData/projectdata.cpp
@@ -1,6 +1,9 @@
 
 #include "ProjectData\projectdata.h"
 
+
+#include "App/global.h"
+
 ProjectData::ProjectData() :
     QObject(nullptr),
     _projectSettings(new ProjectSettings(this)),
@@ -66,7 +69,6 @@ void ProjectData::addBusstop(Busstop *b) {
     if(!b)
         return;
 
-    b->setParent(this);
     _busstops << b;
 }
 void ProjectData::addLine(Line *l) {
@@ -607,7 +609,7 @@ void ProjectData::setJson(const QJsonObject &jsonObject) {
     for(int i = 0; i < jBusstops.count(); ++i)
         if(jBusstops[i].isObject()) {
             counter++;
-            addBusstop(new Busstop(this, jBusstops[i].toObject()));
+            addBusstop(newBusstop(jBusstops[i].toObject()));
         } else invalidCounter++;
 
     qInfo().noquote() << counter << "valid busstops found (" + QString::number(invalidCounter) + " invalid)";
@@ -643,11 +645,18 @@ void ProjectData::setJson(const QJsonObject &jsonObject) {
     publications()->setJson(jsonObject.value("publications").toObject());
 }
 
+Busstop *ProjectData::newBusstop(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new Busstop(this, id);
+}
 
+Busstop *ProjectData::newBusstop(const QJsonObject &obj) {
+    return new Busstop(this, obj);
+}
 
-
-
-
-
-
-
+Busstop *ProjectData::newBusstop(const Busstop &newBusstop) {
+    Busstop *b = new Busstop(newBusstop);
+    b->setParent(this);
+    return b;
+}

--- a/ProjectData/projectdata.cpp
+++ b/ProjectData/projectdata.cpp
@@ -636,7 +636,7 @@ void ProjectData::setJson(const QJsonObject &jsonObject) {
     for(int i = 0; i < jFootnotes.count(); ++i)
         if(jFootnotes[i].isObject()) {
             counter++;
-            addFootnote(new Footnote(this, jFootnotes[i].toObject()));
+            addFootnote(newFootnote(jFootnotes[i].toObject()));
         } else invalidCounter++;
 
     qInfo().noquote() << counter << "valid footnotes found (" + QString::number(invalidCounter) + " invalid)";
@@ -691,4 +691,20 @@ Tour *ProjectData::newTour(const Tour &newTour) {
     Tour *o = new Tour(newTour);
     o->setParent(this);
     return o;
+}
+
+Footnote *ProjectData::newFootnote(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new Footnote(this, id);
+}
+
+Footnote *ProjectData::newFootnote(const QJsonObject &obj) {
+    return new Footnote(this, obj);
+}
+
+Footnote *ProjectData::newFootnote(const Footnote &newFootnote) {
+    Footnote *f = new Footnote(newFootnote);
+    f->setParent(this);
+    return f;
 }

--- a/ProjectData/projectdata.h
+++ b/ProjectData/projectdata.h
@@ -103,6 +103,10 @@ public:
     Busstop *newBusstop(const QJsonObject &);
     Busstop *newBusstop(const Busstop &newBusstop);
 
+    Line *newLine(QString id = "");
+    Line *newLine(const QJsonObject &);
+    Line *newLine(const Line &newLine);
+
 private:
     QString _filePath;
     ProjectSettings *_projectSettings;

--- a/ProjectData/projectdata.h
+++ b/ProjectData/projectdata.h
@@ -111,6 +111,10 @@ public:
     Tour *newTour(const QJsonObject &);
     Tour *newTour(const Tour &newTour);
 
+    Footnote *newFootnote(QString id = "");
+    Footnote *newFootnote(const QJsonObject &);
+    Footnote *newFootnote(const Footnote &newFootnote);
+
 private:
     QString _filePath;
     ProjectSettings *_projectSettings;

--- a/ProjectData/projectdata.h
+++ b/ProjectData/projectdata.h
@@ -107,6 +107,10 @@ public:
     Line *newLine(const QJsonObject &);
     Line *newLine(const Line &newLine);
 
+    Tour *newTour(QString id = "");
+    Tour *newTour(const QJsonObject &);
+    Tour *newTour(const Tour &newTour);
+
 private:
     QString _filePath;
     ProjectSettings *_projectSettings;

--- a/ProjectData/projectdata.h
+++ b/ProjectData/projectdata.h
@@ -99,6 +99,10 @@ public:
     QJsonObject toJson();
     void setJson(const QJsonObject &);
 
+    Busstop *newBusstop(QString id = "");
+    Busstop *newBusstop(const QJsonObject &);
+    Busstop *newBusstop(const Busstop &newBusstop);
+
 private:
     QString _filePath;
     ProjectSettings *_projectSettings;

--- a/ProjectData/projectsettings.cpp
+++ b/ProjectData/projectsettings.cpp
@@ -59,12 +59,28 @@ void ProjectSettings::setJson(const QJsonObject &jsonObject) {
 
     for(int i = 0; i < jDayTypes.count(); ++i)
         if(jDayTypes.at(i).isObject())
-            addDayType(new DayType(this, jDayTypes.at(i).toObject()));
+            addDayType(newDayType(jDayTypes.at(i).toObject()));
 }
 
 void ProjectSettings::refreshChilds() {
     foreach(DayType *dt, _dayTypes)
         dt->setParent(this);
+}
+
+DayType *ProjectSettings::newDayType(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new DayType(this, id);
+}
+
+DayType *ProjectSettings::newDayType(const QJsonObject &obj) {
+    return new DayType(this, obj);
+}
+
+DayType *ProjectSettings::newDayType(const DayType &newDayType) {
+    DayType *dt = new DayType(newDayType);
+    dt->setParent(this);
+    return dt;
 }
 
 QJsonObject ProjectSettings::toJson() const {

--- a/ProjectData/projectsettings.h
+++ b/ProjectData/projectsettings.h
@@ -42,6 +42,10 @@ public:
 
     void refreshChilds();
 
+    DayType *newDayType(QString id = "");
+    DayType *newDayType(const QJsonObject &);
+    DayType *newDayType(const DayType &newDayType);
+
 protected:
     void copy(const ProjectSettings &);
 

--- a/ProjectData/publications.cpp
+++ b/ProjectData/publications.cpp
@@ -44,7 +44,7 @@ void Publications::setJson(const QJsonObject &jsonObject) {
 
     for(int i = 0; i < jLineSchedules.count(); ++i)
         if(jLineSchedules.at(i).isObject())
-            addLine(new PublishedLine(this, jLineSchedules.at(i).toObject()));
+            addLine(newLine(jLineSchedules.at(i).toObject()));
 }
 
 void Publications::refreshChilds() {
@@ -121,4 +121,21 @@ void Publications::removeLine(const QString &id) {
     for(int i = 0; i < lineCount(); i++)
         if(lineAt(i)->id() == id)
             _lines.remove(i);
+}
+
+
+PublishedLine *Publications::newLine(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new PublishedLine(this, id);
+}
+
+PublishedLine *Publications::newLine(const QJsonObject &obj) {
+    return new PublishedLine(this, obj);
+}
+
+PublishedLine *Publications::newLine(const PublishedLine &newLine) {
+    PublishedLine *l = new PublishedLine(newLine);
+    l->setParent(this);
+    return l;
 }

--- a/ProjectData/publications.h
+++ b/ProjectData/publications.h
@@ -30,6 +30,10 @@ public:
 
     void reset();
 
+    PublishedLine *newLine(QString id = "");
+    PublishedLine *newLine(const QJsonObject &);
+    PublishedLine *newLine(const PublishedLine &newLine);
+
 protected:
     void copy(const Publications &);
 

--- a/ProjectData/publishedbusstop.cpp
+++ b/ProjectData/publishedbusstop.cpp
@@ -2,8 +2,8 @@
 
 #include "ProjectData.h"
 
-PublishedBusstop::PublishedBusstop(QObject *parent, const QString &id, Busstop *linkedBusstop, const QString &label) :
-    ProjectDataItem(parent, id), _linkedBusstop(linkedBusstop), _label(label), _showDivider(false) {}
+PublishedBusstop::PublishedBusstop(QObject *parent, const QString &id) :
+    ProjectDataItem(parent, id), _showDivider(false) {}
 
 PublishedBusstop::PublishedBusstop(QObject *parent, const QJsonObject &jsonObject) :
     ProjectDataItem(parent) {

--- a/ProjectData/publishedbusstop.h
+++ b/ProjectData/publishedbusstop.h
@@ -8,7 +8,7 @@
 class PublishedBusstop : public virtual ProjectDataItem {
     Q_OBJECT
 public:
-    PublishedBusstop(QObject *parent, const QString &id, Busstop *linkedBusstop, const QString &label = "");
+    PublishedBusstop(QObject *parent, const QString &id);
     PublishedBusstop(QObject *parent, const QJsonObject &);
     PublishedBusstop(const PublishedBusstop &);
     PublishedBusstop operator=(const PublishedBusstop &);

--- a/ProjectData/publishedline.cpp
+++ b/ProjectData/publishedline.cpp
@@ -62,7 +62,7 @@ void PublishedLine::fromJson(const QJsonObject &jsonObject) {
 
     QJsonArray jDirections = jsonObject.value("directions").toArray();
     for(int i = 0; i < jDirections.count(); ++i)
-        addDirection(new PublishedLineDirection(this, jDirections.at(i).toObject()));
+        addDirection(newDirection(jDirections.at(i).toObject()));
 }
 
 
@@ -203,4 +203,20 @@ void PublishedLine::removeDayType(DayType *dt) {
     for(int i = 0; i < dayTypeCount(); i++)
         if(_dayTypes[i] == dt)
             _dayTypes.remove(i);
+}
+
+PublishedLineDirection *PublishedLine::newDirection(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new PublishedLineDirection(this, id);
+}
+
+PublishedLineDirection *PublishedLine::newDirection(const QJsonObject &obj) {
+    return new PublishedLineDirection(this, obj);
+}
+
+PublishedLineDirection *PublishedLine::newDirection(const PublishedLineDirection &newDirection) {
+    PublishedLineDirection *ld = new PublishedLineDirection(newDirection);
+    ld->setParent(this);
+    return ld;
 }

--- a/ProjectData/publishedline.cpp
+++ b/ProjectData/publishedline.cpp
@@ -1,7 +1,7 @@
 #include "publishedline.h"
 
-PublishedLine::PublishedLine(QObject *parent, const QString &id, const QString &title, const QString &footer) :
-    ProjectDataItem(parent, id), _title(title), _footer(footer) {}
+PublishedLine::PublishedLine(QObject *parent, const QString &id) :
+    ProjectDataItem(parent, id) {}
 
 PublishedLine::PublishedLine(QObject *parent, const QJsonObject &jsonObject) :
     ProjectDataItem(parent) {

--- a/ProjectData/publishedline.h
+++ b/ProjectData/publishedline.h
@@ -9,7 +9,7 @@
 class PublishedLine : public virtual ProjectDataItem {
     Q_OBJECT
 public:
-    PublishedLine(QObject *parent, const QString &id, const QString &title, const QString &footer = "");
+    PublishedLine(QObject *parent, const QString &id);
     PublishedLine(QObject *parent, const QJsonObject &);
     PublishedLine(const PublishedLine &);
     PublishedLine operator=(const PublishedLine &);

--- a/ProjectData/publishedline.h
+++ b/ProjectData/publishedline.h
@@ -47,6 +47,10 @@ public:
 
     void refreshChilds();
 
+    PublishedLineDirection *newDirection(QString id = "");
+    PublishedLineDirection *newDirection(const QJsonObject &);
+    PublishedLineDirection *newDirection(const PublishedLineDirection &newDirection);
+
 protected:
     void copy(const PublishedLine &);
     void fromJson(const QJsonObject &);

--- a/ProjectData/publishedlinedirection.cpp
+++ b/ProjectData/publishedlinedirection.cpp
@@ -47,7 +47,7 @@ void PublishedLineDirection::fromJson(const QJsonObject &jsonObject) {
     QJsonArray jRoutes = jsonObject.value("routes").toArray();
 
     for(int i = 0; i < jBusstops.count(); ++i)
-        addBusstop(new PublishedBusstop(this, jBusstops.at(i).toObject()));
+        addBusstop(newBusstop(jBusstops.at(i).toObject()));
 
     for(int i = 0; i < jRoutes.count(); ++i) {
         Route *r = static_cast<ProjectData *>(parent()->parent()->parent())->route(jRoutes.at(i).toString(""));
@@ -200,4 +200,20 @@ bool PublishedLineDirection::hasRoute(Route *r) {
     }
 
     return false;
+}
+
+PublishedBusstop *PublishedLineDirection::newBusstop(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new PublishedBusstop(this, id);
+}
+
+PublishedBusstop *PublishedLineDirection::newBusstop(const QJsonObject &obj) {
+    return new PublishedBusstop(this, obj);
+}
+
+PublishedBusstop *PublishedLineDirection::newBusstop(const PublishedBusstop &newBusstop) {
+    PublishedBusstop *b = new PublishedBusstop(newBusstop);
+    b->setParent(this);
+    return b;
 }

--- a/ProjectData/publishedlinedirection.cpp
+++ b/ProjectData/publishedlinedirection.cpp
@@ -2,11 +2,8 @@
 
 #include "ProjectData.h"
 
-PublishedLineDirection::PublishedLineDirection(QObject *parent,
-                                               const QString &id,
-                                               const QString &name) :
-    ProjectDataItem(parent, id),
-    _name(name) {}
+PublishedLineDirection::PublishedLineDirection(QObject *parent, const QString &id) :
+    ProjectDataItem(parent, id) {}
 
 PublishedLineDirection::PublishedLineDirection(QObject *parent, const QJsonObject &jsonObject) :
     ProjectDataItem(parent) {

--- a/ProjectData/publishedlinedirection.h
+++ b/ProjectData/publishedlinedirection.h
@@ -44,6 +44,10 @@ public:
 
     void refreshChilds();
 
+    PublishedBusstop *newBusstop(QString id = "");
+    PublishedBusstop *newBusstop(const QJsonObject &);
+    PublishedBusstop *newBusstop(const PublishedBusstop &newBusstop);
+
 protected:
     void copy(const PublishedLineDirection &);
     void fromJson(const QJsonObject &);

--- a/ProjectData/publishedlinedirection.h
+++ b/ProjectData/publishedlinedirection.h
@@ -10,7 +10,7 @@
 class PublishedLineDirection : public virtual ProjectDataItem {
     Q_OBJECT
 public:
-    PublishedLineDirection(QObject *parent, const QString &id, const QString &name);
+    PublishedLineDirection(QObject *parent, const QString &id);
     PublishedLineDirection(QObject *parent, const QJsonObject &);
     PublishedLineDirection(const PublishedLineDirection &);
     PublishedLineDirection operator=(const PublishedLineDirection &);

--- a/ProjectData/route.cpp
+++ b/ProjectData/route.cpp
@@ -63,7 +63,7 @@ void Route::fromJson(const QJsonObject &jsonObject) {
 
     for(int i = 0; i < jTimeProfiles.count(); ++i)
         if(jTimeProfiles[i].isObject())
-            addTimeProfile(new TimeProfile(this, jTimeProfiles[i].toObject()));
+            addTimeProfile(newTimeProfile(jTimeProfiles[i].toObject()));
 }
 
 QJsonObject Route::toJson() const {
@@ -277,4 +277,20 @@ int Route::indexOfTimeProfile(TimeProfile* p) const {
             return i;
 
     return -1;
+}
+
+TimeProfile *Route::newTimeProfile(QString id) {
+    if(id.isEmpty())
+        id = ProjectDataItem::getNewID();
+    return new TimeProfile(this, id);
+}
+
+TimeProfile *Route::newTimeProfile(const QJsonObject &obj) {
+    return new TimeProfile(this, obj);
+}
+
+TimeProfile *Route::newTimeProfile(const TimeProfile &newTimeProfile) {
+    TimeProfile *p = new TimeProfile(newTimeProfile);
+    p->setParent(this);
+    return p;
 }

--- a/ProjectData/route.cpp
+++ b/ProjectData/route.cpp
@@ -3,13 +3,8 @@
 #include "ProjectDataItem.h"
 #include "projectdata.h"
 
-Route::Route(QObject *parent,
-             const QString &id,
-             const int &code,
-             const QString &name,
-             LineDirection *direction) :
-    ProjectDataItem(parent, id),
-    _code(code), _direction(direction), _name(name) {}
+Route::Route(QObject *parent, const QString &id) :
+    ProjectDataItem(parent, id), _code(1) {}
 
 Route::Route(QObject *parent, const QJsonObject &jsonObject) :
     ProjectDataItem(parent) {

--- a/ProjectData/route.h
+++ b/ProjectData/route.h
@@ -11,7 +11,7 @@
 class Route : public virtual ProjectDataItem {
     Q_OBJECT
 public:
-    Route(QObject *parent, const QString &id, const int &code, const QString &name, LineDirection *direction);
+    Route(QObject *parent, const QString &id);
     Route(QObject *parent, const QJsonObject &);
     Route(const Route &);
     bool operator<(const Route &);

--- a/ProjectData/route.h
+++ b/ProjectData/route.h
@@ -59,6 +59,10 @@ public:
 
     void refreshChilds();
 
+    TimeProfile *newTimeProfile(QString id = "");
+    TimeProfile *newTimeProfile(const QJsonObject &);
+    TimeProfile *newTimeProfile(const TimeProfile &newTimeProfile);
+
 protected:
     void copy(const Route &);
     void fromJson(const QJsonObject &);

--- a/ProjectData/timeProfile.cpp
+++ b/ProjectData/timeProfile.cpp
@@ -116,8 +116,8 @@ bool TimeProfileItem::hasSeperateTimes() const {
     return _seperateTimes;
 }
 
-TimeProfile::TimeProfile(QObject *parent, const QString &id, const QString &name) :
-    ProjectDataItem(parent, id), _name(name) {
+TimeProfile::TimeProfile(QObject *parent, const QString &id) :
+    ProjectDataItem(parent, id) {
 
 }
 

--- a/ProjectData/timeProfile.h
+++ b/ProjectData/timeProfile.h
@@ -52,7 +52,7 @@ class TimeProfile : public ProjectDataItem
 {
     Q_OBJECT
 public:
-    TimeProfile(QObject *parent, const QString &id, const QString &name);
+    TimeProfile(QObject *parent, const QString &id);
     TimeProfile(QObject *parent, const QJsonObject &);
     TimeProfile(const TimeProfile &);
     TimeProfile operator=(const TimeProfile &);

--- a/ProjectData/tour.cpp
+++ b/ProjectData/tour.cpp
@@ -1,8 +1,8 @@
 #include "ProjectData\tour.h"
 #include "projectdata.h"
 
-Tour::Tour(QObject *parent, const QString &id, const QString &name, const WeekDays &weekDays) :
-    ProjectDataItem(parent, id), _name(name), _weekDays(weekDays) {
+Tour::Tour(QObject *parent, const QString &id) :
+    ProjectDataItem(parent, id) {
 }
 
 Tour::Tour(QObject *parent, const QJsonObject &jsonObject) :

--- a/ProjectData/tour.h
+++ b/ProjectData/tour.h
@@ -10,7 +10,7 @@
 class Tour : public virtual ProjectDataItem {
     Q_OBJECT
 public:
-    Tour(QObject *parent, const QString &id, const QString &name, const WeekDays &weekDays = WeekDays(nullptr));
+    Tour(QObject *parent, const QString &id);
     Tour(QObject *parent, const QJsonObject &);
     Tour(const Tour &);
     Tour operator=(const Tour &);

--- a/ProjectData/trip.cpp
+++ b/ProjectData/trip.cpp
@@ -2,15 +2,8 @@
 #include "timeProfile.h"
 #include "line.h"
 
-Trip::Trip(QObject *parent,
-           const QString &id,
-           Route *route,
-           const QTime &startTime,
-           TimeProfile *timeProfile,
-           const WeekDays &weekDays) :
-    ProjectDataItem(parent, id),
-    _route(route), _startTime(startTime), _weekDays(weekDays),
-    _timeProfile(timeProfile) {}
+Trip::Trip(QObject *parent, const QString &id) :
+    ProjectDataItem(parent, id) {}
 
 Trip::Trip(QObject *parent, const QJsonObject &jsonObject) :
     ProjectDataItem(parent) {

--- a/ProjectData/trip.h
+++ b/ProjectData/trip.h
@@ -11,7 +11,7 @@
 class Trip : public virtual ProjectDataItem {
     Q_OBJECT
 public:
-    Trip(QObject *parent, const QString &id, Route* route, const QTime &startTime, TimeProfile *timeProfile, const WeekDays &weekDays = WeekDays(nullptr));
+    Trip(QObject *parent, const QString &id);
     Trip(QObject *parent, const QJsonObject &);
     Trip(const Trip &);
     bool operator<(const Trip &);

--- a/Widgets/Publications/wdgpublishedlines.cpp
+++ b/Widgets/Publications/wdgpublishedlines.cpp
@@ -66,7 +66,8 @@ void WdgPublishedLines::actionNew() {
     if(!ok)
         return;
 
-    PublishedLine *l = new PublishedLine(nullptr, global::getNewID(), name);
+    PublishedLine *l = projectData->publications()->newLine();
+    l->setTitle(name);
     undoStack->push(new CmdPublishedLineNew(projectData, l));
     _currentLine = l;
     refreshLineList();

--- a/Widgets/Publications/wdgpublishedlines.cpp
+++ b/Widgets/Publications/wdgpublishedlines.cpp
@@ -159,7 +159,8 @@ void WdgPublishedLines::actionBusstopAdd() {
     if(busstopFound)
         return;
 
-    PublishedBusstop *pb = new PublishedBusstop(nullptr, global::getNewID(), b, "");
+    PublishedBusstop *pb = _currentLineDirection->newBusstop();
+    pb->setLinkedBusstop(b);
 
     PublishedLineDirection newLd = *_currentLineDirection;
 

--- a/Widgets/Publications/wdgpublishedlines.cpp
+++ b/Widgets/Publications/wdgpublishedlines.cpp
@@ -109,7 +109,8 @@ void WdgPublishedLines::actionDirectionNew() {
     if(!ok)
         return;
 
-    PublishedLineDirection *ld = new PublishedLineDirection(nullptr, global::getNewID(), name);
+    PublishedLineDirection *ld = _currentLine->newDirection();
+    ld->setName(name);
     undoStack->push(new CmdPublishedLineDirectionNew(_currentLine, ld));
     _currentLineDirection = ld;
     refreshCurrentLine();

--- a/Widgets/WdgFootnotes.cpp
+++ b/Widgets/WdgFootnotes.cpp
@@ -39,7 +39,10 @@ void WdgFootnotes::actionNew() {
     if(dlg.result() != QDialog::Accepted)
         return;
 
-    Footnote *f = new Footnote(projectData, global::getNewID(), dlg.identifier(), dlg.name(), dlg.description());
+    Footnote *f = projectData->newFootnote();
+    f->setIdentifier(dlg.identifier());
+    f->setName(dlg.name());
+    f->setDescription(dlg.description());
     f->setAutoAssignWeekDaysEnabled(dlg.autoAssignWeekDaysEnabled());
     f->setAutoAssignWeekDays(dlg.weekDays());
     f->setAutoAssignCareWeekDays(dlg.careWeekDays());
@@ -104,7 +107,10 @@ void WdgFootnotes::actionDuplicate() {
     if(dlg.result() != QDialog::Accepted)
         return;
 
-    Footnote *newF = new Footnote(projectData, global::getNewID(), dlg.identifier(), dlg.name(), dlg.description());
+    Footnote *newF = projectData->newFootnote();
+    newF->setIdentifier(dlg.identifier());
+    newF->setName(dlg.name());
+    newF->setDescription(dlg.description());
 
     newF->setAutoAssignWeekDaysEnabled(dlg.autoAssignWeekDaysEnabled());
     newF->setAutoAssignWeekDays(dlg.weekDays());

--- a/Widgets/wdgbusstops.cpp
+++ b/Widgets/wdgbusstops.cpp
@@ -63,7 +63,9 @@ void WdgBusstops::actionNew() {
     if(name == "")
         return;
 
-    Busstop *b = new Busstop(nullptr, global::getNewID(), name, important);
+    Busstop *b = projectData->newBusstop();
+    b->setName(name);
+    b->setImportant(important);
     undoStack->push(new CmdBusstopNew(projectData, b));
     emit refreshRequested();
 }

--- a/Widgets/wdglines.cpp
+++ b/Widgets/wdglines.cpp
@@ -66,9 +66,10 @@ void WdgLines::actionNew() {
     if(dlg.result() != QDialog::Accepted)
         return;
 
-    Line *l = new Line(dlg.line());
-    if(l->name() == "")
+    if(dlg.line().name().isEmpty())
         return;
+
+    Line *l = projectData->newLine(dlg.line());
 
     undoStack->push(new CmdLineNew(projectData, l));
     emit refreshRequested();

--- a/Widgets/wdgroutes.cpp
+++ b/Widgets/wdgroutes.cpp
@@ -67,7 +67,8 @@ void WdgRoutes::actionNew() {
     if(!_currentLine)
         return;
 
-    Route * r = new Route(nullptr, global::getNewID(), 1, "", _currentLine->directionAt(0));
+    Route *r = _currentLine->newRoute();
+    r->setDirection(_currentLine->directionAt(0));
     routeEditor dlg(this, true, r, _currentLine->directions(), projectData->busstops());
     dlg.exec();
 
@@ -130,7 +131,10 @@ void WdgRoutes::actionDuplicate() {
     if(dlg.result() != QDialog::Accepted)
         return;
 
-    Route * n = new Route(nullptr, global::getNewID(), dlg.getCode(), dlg.name(), dlg.getDirection());
+    Route *n = _currentLine->newRoute();
+    n->setCode(dlg.getCode());
+    n->setName(dlg.name());
+    n->setDirection(dlg.getDirection());
     QStringList busstopList = dlg.getBusstopList();
 
     for(int i = 0; i < busstopList.count(); i++) {

--- a/Widgets/wdgtours.cpp
+++ b/Widgets/wdgtours.cpp
@@ -62,7 +62,9 @@ void WdgTours::actionTourNew() {
     if(dlg.result() != QDialog::Accepted)
         return;
     
-    Tour *o = new Tour(nullptr, global::getNewID(), dlg.name(), dlg.weekDays());
+    Tour *o = projectData->newTour();
+    o->setName(dlg.name());
+    o->setWeekDays(dlg.weekDays());
     undoStack->push(new CmdTourNew(projectData, o));
     refresh();
 }
@@ -97,7 +99,9 @@ void WdgTours::actionTourDuplicate() {
     if(dlg.result() != QDialog::Accepted)
         return;
     
-    Tour *nO = new Tour(nullptr, global::getNewID(), dlg.name(), dlg.weekDays());
+    Tour *nO = projectData->newTour();
+    nO->setName(dlg.name());
+    nO->setWeekDays(dlg.weekDays());
     undoStack->push(new CmdTourNew(projectData, nO));
     refresh();
 }

--- a/Widgets/wdgtripeditor.cpp
+++ b/Widgets/wdgtripeditor.cpp
@@ -75,7 +75,11 @@ void WdgTripEditor::actionNew() {
     if(!startTime.isValid())
         startTime.setHMS(0, 0, 0, 0);
 
-    Trip *t = new Trip(nullptr, global::getNewID(), _currentRoute, startTime, p, _currentDayType);
+    Trip *t = _currentLine->newTrip();
+    t->setRoute(_currentRoute);
+    t->setStartTime(startTime);
+    t->setTimeProfile(p);
+    t->setWeekDays(_currentDayType);
     undoStack->push(new CmdScheduleTripNew(_currentLine, t));
     _currentTrips = {t};
     emit tripsChanged(_currentTrips);
@@ -99,8 +103,10 @@ void WdgTripEditor::actionCopy() {
 
     QList<Trip *> trips;
     for(int i = 0; i < count; i++) {
-        Trip *t = new Trip(nullptr, global::getNewID(), currentTrip->route(), currentTrip->startTime(), currentTrip->timeProfile());
+        Trip *t = _currentLine->newTrip();
+        t->setRoute(currentTrip->route());
         t->setStartTime(QTime::fromMSecsSinceStartOfDay(currentTrip->startTime().msecsSinceStartOfDay() + ((i + 1) * interval.msecsSinceStartOfDay())));
+        t->setTimeProfile(currentTrip->timeProfile());
         trips << t;
     }
 


### PR DESCRIPTION
There are still issues with all kind of projectData with it's QObject::parenting, so we can't ensure that all of that data is deleted correctly when the file is closed but also the application crashes sometimes when stuff is deleted, which is still necessary.
This is a huge problem, especially when it comes to larger projects and bigger amount of data.
We use the QObject's parenting and object hierarchy system to control when an object should be deleted.
But the problem is: new Objects are created all over the entire application and it's not possible to ensure that all objects always get the correct parent.
To fix this issue and improve the code I suggest:
- move all "generatings" of objects to a central place in the code:
- every projectDataItem that can or should own other projectDataItems gets a special "new"-Functions which generates a new child, sets is as a child, adds it and returns it. For example (in Line class):
```
Route *newRoute(const Route &newRoute) {
   // create new Route object by copying the given one
   Route *r = new Route(newRoute);
   // set parent
   r->setParent(this);
   // add to "myself"
   addRoute(r);
   // return for further modification if necessary
   return r;
}
```
From everywhere when a new object is needed it can use this new function. With that we can ensure that every object gets the right parent and (!) lives in the right thread (which is a problem with the PlgOmsiImporter for example).